### PR TITLE
Add support for the ++help command

### DIFF
--- a/src/AR488/AR488.ino
+++ b/src/AR488/AR488.ino
@@ -19,7 +19,7 @@
 #endif
 #ifdef E2END
   #include <EEPROM.h>
-  
+
 #endif
 
 #ifdef AR_BT_EN
@@ -289,7 +289,7 @@ const char * const macros[] PROGMEM = {
 
 /***** PARSE BUFFERS *****/
 /*
- * Note: Ardiono serial input buffer is 64 
+ * Note: Ardiono serial input buffer is 64
  */
 // Serial input parsing buffer
 static const uint8_t PBSIZE = 128;
@@ -360,7 +360,7 @@ uint8_t pbPtr = 0;
 #define PLUS 0x2B   // '+' character
 
 /***** Controller configuration *****/
-/*   
+/*
  * Default values set for controller mode
  */
 union AR488conf{
@@ -399,7 +399,7 @@ uint8_t cstate = 0;
 bool isVerb = false;
 
 // CR/LF terminated line ready to process
-uint8_t lnRdy = 0;      
+uint8_t lnRdy = 0;
 
 // GPIB data receive flags
 //bool isReading = false; // Is a GPIB read in progress?
@@ -487,7 +487,7 @@ void setup() {
 
  // Initialise serial comms over USB or Bluetooth
 #ifdef AR_BT_EN
-  // Initialise Bluetooth  
+  // Initialise Bluetooth
   btInit();
   arSerial->begin(AR_BT_BAUD);
 #else
@@ -501,7 +501,7 @@ void setup() {
 
 
 // Un-comment for diagnostic purposes
-/* 
+/*
   #if defined(__AVR_ATmega32U4__)
     while(!*arSerial)
     ;
@@ -542,7 +542,7 @@ void setup() {
   if (AR488.cmode==2) {
     // Set controller mode on SN75161/2
     digitalWrite(SN7516X_TE, LOW);
-    #ifdef SN7516X_DC 
+    #ifdef SN7516X_DC
       digitalWrite(SN7516X_DC, LOW);
     #endif
     #ifdef SN7516X_SC
@@ -600,7 +600,7 @@ void loop() {
 /*** Pin Hooks ***/
 /*
  * Not all boards support interrupts or have PCINTs. In this
- * case, use in-loop checking to detect when SRQ and ATN have 
+ * case, use in-loop checking to detect when SRQ and ATN have
  * been signalled
  */
 #ifndef USE_INTERRUPTS
@@ -609,7 +609,7 @@ void loop() {
 #endif
 
 /*** Process the buffer ***/
-/* Each received char is passed through parser until an un-escaped 
+/* Each received char is passed through parser until an un-escaped
  * CR is encountered. If we have a command then parse and execute.
  * If the line is data (inclding direct instrument commands) then
  * send it to the instrument.
@@ -676,7 +676,7 @@ void loop() {
 
   // Check serial buffer
   lnRdy = serialIn_h();
-  
+
   delayMicroseconds(5);
 }
 /***** END MAIN LOOP *****/
@@ -713,13 +713,13 @@ void initController() {
 /***** Serial event handler *****/
 /*
  * Note: the Arduino serial buffer is 64 characters long. Characters are stored in
- * this buffer until serialEvent_h() is called. parsedInput() takes a character at 
+ * this buffer until serialEvent_h() is called. parsedInput() takes a character at
  * a time and places it into the 256 character parse buffer whereupon it is parsed
  * to determine whether a command or data are present.
  * lnRdy=0: terminator not detected yet
  * lnRdy=1: terminator detected, sequence in parse buffer is a ++ command
  * lnRdy=2: terminator detected, sequence in parse buffer is data or direct instrument command
- */ 
+ */
 uint8_t serialIn_h() {
   uint8_t bufferStatus = 0;
   // Parse serial input until we have detected a line terminator
@@ -730,7 +730,7 @@ uint8_t serialIn_h() {
 #ifdef DEBUG1
   if (bufferStatus) {
     dbSerial->print(F("BufferStatus: "));
-    dbSerial->println(bufferStatus);  
+    dbSerial->println(bufferStatus);
   }
 #endif
 
@@ -801,7 +801,7 @@ uint8_t parseInput(char c) {
               if (pBuf[2]==0x21) {
                 r = 3;
                 flushPbuf();
-              // Otherwise flag command received and ready to process 
+              // Otherwise flag command received and ready to process
               }else{
                 r = 1;
               }
@@ -916,26 +916,25 @@ void flushPbuf() {
 
 
 /***** Comand function record *****/
-struct cmdRec { 
-  const char* token; 
+struct cmdRec {
+  const char* token;
   int opmode;
   void (*handler)(char *);
 };
-
 
 /***** Array containing index of accepted ++ commands *****/
 /*
  * Commands without parameters require casting to a pointer
  * requiring a char* parameter. The functon is called with
  * NULL by the command processor.
- * 
+ *
  * Format: token, mode, function_ptr
- * Mode: 1=device; 2=controller; 3=both; 
+ * Mode: 1=device; 2=controller; 3=both;
  */
-static cmdRec cmdHidx [] = { 
- 
-  { "addr",        3, addr_h      }, 
-  { "allspoll",    2, (void(*)(char*)) aspoll_h  },
+static cmdRec cmdHidx [] = {
+
+  { "addr",        3, addr_h      },
+  { "aspoll",      2, (void(*)(char*)) aspoll_h  },
   { "auto",        2, amode_h     },
   { "clr",         2, (void(*)(char*)) clr_h     },
   { "dcl",         2, (void(*)(char*)) dcl_h     },
@@ -1131,7 +1130,7 @@ void getCmd(char *buffr) {
 
   char *token;  // Pointer to command token
   char *params; // Pointer to parameters (remaining buffer characters)
-  
+
   int casize = sizeof(cmdHidx) / sizeof(cmdHidx[0]);
   int i = 0;
 
@@ -1140,7 +1139,7 @@ void getCmd(char *buffr) {
   dbSerial->print(buffr); dbSerial->print(F(" - length:")); dbSerial->println(strlen(buffr));
 #endif
 
-  // If terminator on blank line then return immediately without processing anything 
+  // If terminator on blank line then return immediately without processing anything
   if (buffr[0] == 0x00) return;
   if (buffr[0] == CR) return;
   if (buffr[0] == LF) return;
@@ -1169,7 +1168,7 @@ void getCmd(char *buffr) {
       // If its a command with parameters
       // Copy command parameters to params and call handler with parameters
       params = token + strlen(token) + 1;
-  
+
       // If command parameters were specified
       if (strlen(params) > 0) {
 #ifdef DEBUG1
@@ -1180,7 +1179,7 @@ void getCmd(char *buffr) {
       }else{
         // Call handler without parameters
         cmdHidx[i].handler(NULL);
-      }   
+      }
     }else{
       errBadCmd();
       if (isVerb) arSerial->println(F("Command not available in this mode."));
@@ -1190,7 +1189,7 @@ void getCmd(char *buffr) {
     // No valid command found
     errBadCmd();
   }
- 
+
 }
 
 
@@ -1206,7 +1205,7 @@ void printHex(char *buffr, int dsize) {
 /***** Check whether a parameter is in range *****/
 /* Convert string to integer and check whether value is within
  * lowl to higl inclusive. Also returns converted text in param
- * to a uint16_t integer in rval. Returns true if successful, 
+ * to a uint16_t integer in rval. Returns true if successful,
  * false if not
 */
 bool notInRange(char *param, uint16_t lowl, uint16_t higl, uint16_t &rval) {
@@ -1591,7 +1590,7 @@ void loc_h(char *params) {
 
 /***** Assert IFC for 150 microseconds *****/
 /* This indicates that the AR488 the Controller-in-Charge on
- * the bus and causes all interfaces to return to their idle 
+ * the bus and causes all interfaces to return to their idle
  * state
  */
 void ifc_h() {
@@ -1671,7 +1670,7 @@ void trg_h(char *params) {
  * For other devices, we restart the program instead by
  * jumping to address 0x0000. This is not a hardware reset
  * and will not reset a crashed MCU, but it will re-start
- * the interface program and re-initialise all parameters. 
+ * the interface program and re-initialise all parameters.
  */
 void rst_h() {
 #ifdef WDTO_1S
@@ -2065,8 +2064,8 @@ arSerial->println(idparams);
 */
 
   id_h(idparams);
-  
-/*  
+
+/*
   if (params != NULL) {
     len = strlen(params);
     if (len>47) len=47; // Ignore anything over 47 characters
@@ -2077,7 +2076,7 @@ arSerial->println(idparams);
       arSerial->println(params);
     };
   }
-*/  
+*/
 }
 
 
@@ -2206,7 +2205,7 @@ void xdiag_h(char *params){
   char *param;
   uint8_t mode = 0;
   uint8_t val = 0;
-  
+
   // Get first parameter (mode = 0 or 1)
   param = strtok(params, " \t");
   if (param != NULL) {
@@ -2289,7 +2288,7 @@ void id_h(char *params) {
     dlen = strlen(datastr);
     if (dlen) {
       if (strncmp(keyword, "verstr", 6)==0) {
-#ifdef DEBUG10       
+#ifdef DEBUG10
         arSerial->print(F("Keyword: "));
         arSerial->println(keyword);
         arSerial->print(F("DataStr: "));
@@ -2332,16 +2331,16 @@ void id_h(char *params) {
       if (strncmp(keyword, "verstr", 6)==0) {
         arSerial->println(AR488.vstr);
         return;
-      }     
+      }
       if (strncmp(keyword, "name", 4)==0) {
         arSerial->println(AR488.sname);
-        return;      
+        return;
       }
       if (strncmp(keyword, "serial", 6)==0) {
         memset(serialStr, '\0', 10);
-        snprintf(serialStr, 10, "%09lu", AR488.serial);  // Max str length = 10-1 i.e 9 digits + null terminator 
+        snprintf(serialStr, 10, "%09lu", AR488.serial);  // Max str length = 10-1 i.e 9 digits + null terminator
         arSerial->println(serialStr);
-        return;    
+        return;
       }
     }
   }
@@ -2356,13 +2355,13 @@ void idn_h(char * params){
     AR488.idn = (uint8_t)val;
     if (isVerb) {
       arSerial->print(F("Sending IDN: "));
-      arSerial->print(val ? "Enabled" : "Disabled"); 
+      arSerial->print(val ? "Enabled" : "Disabled");
       if (val==2) arSerial->print(F(" with serial number"));
       arSerial->println();
     };
   } else {
     arSerial->println(AR488.idn, DEC);
-  }  
+  }
 }
 
 
@@ -2383,7 +2382,7 @@ void attnRequired() {
   bool spe = false;
   bool spd = false;
   bool eoiDetected = false;
-  
+
   // Set device listner active state (assert NDAC+NRFD (low), DAV=INPUT_PULLUP)
   setGpibControls(DLAS);
 
@@ -2423,7 +2422,7 @@ void attnRequired() {
 
       // Serial poll disable request
       if (db==GC_SPD) spd = true;
- 
+
       // Unlisten
       if (db==GC_UNL) unl_h();
 
@@ -2431,14 +2430,14 @@ void attnRequired() {
       if (db==GC_UNT) unt_h();
 
     }
-  
+
   }
 
 #ifdef DEBUG5
   dbSerial->println(F("End ATN loop."));
 #endif
 
-  if (mla) { 
+  if (mla) {
 #ifdef DEBUG5
     dbSerial->println(F("Listening..."));
 #endif
@@ -2553,7 +2552,7 @@ void lonMode(){
 
   // Clear the buffer to prevent it getting blocked
   if (lnRdy==2) flushPbuf();
-  
+
 }
 
 
@@ -2713,7 +2712,7 @@ void gpibSendData(char *data, uint8_t dsize) {
 #ifdef DEBUG3
     dbSerial->println(F("<- End of send."));
 #endif
- 
+
 }
 
 
@@ -2753,7 +2752,7 @@ bool gpibReceiveData() {
     Wait_on_pin_state(HIGH, NRFD, AR488.rtmo);
     // Set GPIB control lines to controller read mode
     setGpibControls(CLAS);
-    
+
   // Set up for reading in Device mode
   } else {  // Device mode
     // Set GPIB controls to device read mode
@@ -2789,7 +2788,7 @@ bool gpibReceiveData() {
 
     // When reading with amode=3 or EOI check serial input and break loop if neccessary
     if ((AR488.amode==3) || rEoi) lnRdy = serialIn_h();
-    
+
     // Line terminator detected (loop breaks on command being detected or data buffer full)
     if (lnRdy > 0) {
       aRead = false;  // Stop auto read
@@ -3016,7 +3015,7 @@ bool gpibWriteByte(uint8_t db) {
 
 /***** GPIB send byte handshake *****/
 bool gpibWriteByteHandshake(uint8_t db) {
-  
+
     // Wait for NDAC to go LOW (indicating that devices are at attention)
   if (Wait_on_pin_state(LOW, NDAC, AR488.rtmo)) {
     if (isVerb) arSerial->println(F("gpibWriteByte: timeout waiting for receiver attention [NDAC asserted]"));
@@ -3132,7 +3131,7 @@ void setGpibControls(uint8_t state) {
   #ifdef SN7516X_SC
         digitalWrite(SN7516X_SC,HIGH);
   #endif
-#endif      
+#endif
 #ifdef DEBUG2
       dbSerial->println(F("Initialised GPIB control mode"));
 #endif
@@ -3143,7 +3142,7 @@ void setGpibControls(uint8_t state) {
       setGpibState(0b11011111, 0b10011110, 0);
 #ifdef SN7516X
       digitalWrite(SN7516X_TE,LOW);
-#endif      
+#endif
 #ifdef DEBUG2
       dbSerial->println(F("Set GPIB lines to idle state"));
 #endif
@@ -3154,7 +3153,7 @@ void setGpibControls(uint8_t state) {
       setGpibState(0b01011111, 0b10011111, 0);
 #ifdef SN7516X
       digitalWrite(SN7516X_TE,HIGH);
-#endif      
+#endif
 #ifdef DEBUG2
       dbSerial->println(F("Set GPIB lines for sending a command"));
 #endif
@@ -3166,7 +3165,7 @@ void setGpibControls(uint8_t state) {
       setGpibState(0b11011000, 0b10011110, 0);
 #ifdef SN7516X
       digitalWrite(SN7516X_TE,LOW);
-#endif      
+#endif
 #ifdef DEBUG2
       dbSerial->println(F("Set GPIB lines for reading data"));
 #endif
@@ -3177,7 +3176,7 @@ void setGpibControls(uint8_t state) {
       setGpibState(0b11011111, 0b10011110, 0);
 #ifdef SN7516X
       digitalWrite(SN7516X_TE,HIGH);
-#endif      
+#endif
 #ifdef DEBUG2
       dbSerial->println(F("Set GPIB lines for writing data"));
 #endif
@@ -3195,7 +3194,7 @@ void setGpibControls(uint8_t state) {
   #ifdef SN7516X_SC
         digitalWrite(SN7516X_SC,LOW);
   #endif
-#endif      
+#endif
       setGpibState(0b00000000, 0b11111111, 1);
       setGpibState(0b11111111, 0b11111111, 0);
 #ifdef DEBUG2
@@ -3206,7 +3205,7 @@ void setGpibControls(uint8_t state) {
     case DIDS:  // Device idle state
 #ifdef SN7516X
       digitalWrite(SN7516X_TE,HIGH);
-#endif      
+#endif
       setGpibState(0b00000000, 0b00001110, 1);
       setGpibState(0b11111111, 0b00001110, 0);
 #ifdef DEBUG2
@@ -3217,7 +3216,7 @@ void setGpibControls(uint8_t state) {
     case DLAS:  // Device listner active (actively listening - can handshake)
 #ifdef SN7516X
       digitalWrite(SN7516X_TE,LOW);
-#endif      
+#endif
       setGpibState(0b00000110, 0b00001110, 1);
       setGpibState(0b11111001, 0b00001110, 0);
 #ifdef DEBUG2
@@ -3228,7 +3227,7 @@ void setGpibControls(uint8_t state) {
     case DTAS:  // Device talker active (sending data)
 #ifdef SN7516X
       digitalWrite(SN7516X_TE,HIGH);
-#endif      
+#endif
       setGpibState(0b00001000, 0b00001110, 1);
       setGpibState(0b11111001, 0b00001110, 0);
 #ifdef DEBUG2

--- a/src/AR488/AR488.ino
+++ b/src/AR488/AR488.ino
@@ -945,6 +945,7 @@ static cmdRec cmdHidx [] = {
   { "eos",         3, eos_h       },
   { "eot_char",    3, eot_char_h  },
   { "eot_enable",  3, eot_en_h    },
+  { "help",        3, help_h      },
   { "ifc",         2, (void(*)(char*)) ifc_h     },
   { "id",          3, id_h        },
   { "idn",         3, idn_h       },
@@ -975,6 +976,51 @@ static cmdRec cmdHidx [] = {
 };
 
 
+
+static const char cmdHelp[] PROGMEM = {
+  "addr: Display/set device address\n"
+  "auto: Automatically request talk and read response\n"
+  "clr: Send Selected Device Clear to current GPIB address\n"
+  "eoi: Enable/disable assertion of EOI signal\n"
+  "eor: Show or set end of receive character(s)\n"
+  "eos: Specify GPIB termination character\n"
+  "eot_char: Set character to append to USB output when EOT enabled\n"
+  "eot_enable: Enable/Disable appending user specified character to USB output on EOI detection\n"
+  "help: This message\n"
+  "ifc: Assert IFC signal for 150 miscoseconds - make AR488 controller in charge\n"
+  "llo: Local lockout - disable front panel operation on instrument\n"
+  "loc: Enable front panel operation on instrument\n"
+  "lon: Put controller in listen-only mode (listen to all traffic)\n"
+  "mode: Set the interface mode (0=controller/1=device)\n"
+  "read: Read data from instrument\n"
+  "read_tmo_ms: Read timeout specified between 1 - 3000 milliseconds\n"
+  "rst: Reset the controller\n"
+  "savecfg: Save configration\n"
+  "spoll: Serial poll the addressed host or all instruments\n"
+  "srq: Return status of srq signal (1-srq asserted/0-srq not asserted)\n"
+  "status: Set the status byte to be returned on being polled (bit 6 = RQS, i.e SRQ asserted)\n"
+  "trg: Send trigger to selected devices (up to 15 addresses)\n"
+  "ver: Display firmware version\n"
+  // proprietary commands
+  "aspoll: Serial poll all instruments (alias: ++spoll all)\n"
+  "dcl: Send unaddressed (all) device clear  [power on reset] (is the rst?)\n"
+  "default: Set configuration to controller default settings\n"
+  "id name: Show/Set the name of the interface\n"
+  "id serial: Show/Set the serial number of the interface\n"
+  "id verstr: Show/Set the version string (replaces setvstr)\n"
+  "idn: Enable/Disable reply to *idn? (disabled by default)\n"
+  "macro: Run a macro (if macro support is compiled)\n"
+  "ppoll: Conduct a parallel poll\n"
+  "ren: Assert or Unassert the REN signal\n"
+  "repeat: Repeat a given command and return result\n"
+  "setvstr: Set custom version string (to identify controller, e.g. \"GPIB-USB\"). Max 47 chars, excess truncated.\n"
+  "srqauto: Automatically condiuct serial poll when SRQ is asserted\n"
+  "ton: Put controller in talk-only mode (send data only)\n"
+  "verbose: Verbose (human readable) mode\n"
+  "tmbus: Timing parameters (see the doc)\n"
+  "xdiag: Bus diagnostics (see the doc)\n"
+};
+
 /***** Show a prompt *****/
 void showPrompt() {
   // Print prompt
@@ -982,6 +1028,37 @@ void showPrompt() {
   arSerial->print("> ");
 }
 
+/***** Show help message *****/
+void help_h(char *params) {
+  char c;
+  char token[20];
+  int i;
+
+  i = 0;
+  for (int k = 0; k < strlen_P(cmdHelp); k++) {
+    c = pgm_read_byte_near(cmdHelp + k);
+    if (i < 20) {
+      if(c == ':') {
+        token[i] = 0;
+        if((params == NULL) || (strcmp(token, params) == 0)) {
+          arSerial->print(F("++"));
+          arSerial->print(token);
+          arSerial->print(c);
+          i = 255; // means we need to print until \n
+        }
+      } else {
+        token[i] = c;
+        i++;
+      }
+    }
+    else if (i == 255) {
+      arSerial->print(c);
+    }
+    if (c == '\n') {
+      i = 0;
+    }
+  }
+}
 
 /****** Send data to instrument *****/
 /* Processes the parse buffer whenever a full CR or LF


### PR DESCRIPTION
help messages are actually stored as a single string in PROGMEM
because it's a pain in the neck to store an array of strings there.

Support both with or without argument:
- without argument: display all help messages,
- with argument: displa the message for the command given as argument.

Each line is a help message for a command (aka '\n' char is used as
a separator between commands), so no support for multiline help message
for now.

For each line, the first ':' char is used as a separator between the
command name and the help message.

Also clean a bit the AR488.ino file (delete trailing ws).

Tested on an Arduino Uno board only.