### PR TITLE
Fix "btSerial" multiple definition problem

### DIFF
--- a/src/AR488/AR488_BT.cpp
+++ b/src/AR488/AR488_BT.cpp
@@ -27,6 +27,20 @@
 */
 
 #ifdef AR_CDC_SERIAL
+  Serial_ *btSerial = &(AR_SERIAL_PORT);
+#endif
+#ifdef AR_HW_SERIAL
+  HardwareSerial *btSerial = &(AR_SERIAL_PORT);
+#endif
+// Note: SoftwareSerial support conflicts with PCINT support
+#ifdef AR_SW_SERIAL
+  #include <SoftwareSerial.h>
+  SoftwareSerial btSerial(AR_SW_SERIAL_RX, AR_SW_SERIAL_TX);
+  SoftwareSerial *btSerial = &btSerial;
+#endif
+
+/*
+#ifdef AR_CDC_SERIAL
   extern Serial_ *btSerial;
 #endif
 #ifdef AR_HW_SERIAL
@@ -37,6 +51,7 @@
   #include <SoftwareSerial.h>
   extern SoftwareSerial *btSerial;
 #endif
+*/
 
 
 

--- a/src/AR488/AR488_Config.h
+++ b/src/AR488/AR488_Config.h
@@ -315,7 +315,7 @@ M3\n\
 /***** SERIAL PORT EXTERNAL DECLARATIONS *****/
 /******vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv******/
 
-
+/*
 #ifdef AR_BT_EN
   #ifdef AR_CDC_SERIAL
     Serial_ *btSerial = &(AR_SERIAL_PORT);
@@ -330,7 +330,7 @@ M3\n\
     SoftwareSerial *btSerial = &btSerial;
   #endif
 #endif
-
+*/
 
 /******^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^******/
 /***** SERIAL PORT EXTERNAL DECLARATIONS *****/


### PR DESCRIPTION
Declaring the global variable in the header file can have issues. "Multiple btSerial is declared" issue occurs when compiling.
Validated this issue and fix under Arduino 1.8.18 and Arduino 2.00-rc2 released on 2021-12-13.