### PR TITLE
wrap setGpibState calls in something easier to read

### DIFF
--- a/src/AR488/AR488.ino
+++ b/src/AR488/AR488.ino
@@ -1399,11 +1399,9 @@ void loc_h(char *params) {
  */
 void ifc_h() {
   if (gpibBus.cfg.cmode==2) {
-    // Assert IFC
-    gpibBus.setControlVal(0b00000000, 0b00000001, 0);
+    assertCtrl(IFC_BIT);
     delayMicroseconds(150);
-    // De-assert IFC
-    gpibBus.setControlVal(0b00000001, 0b00000001, 0);
+    clearCtrl(IFC_BIT);
     if (isVerb) dataPort.println(F("IFC signal asserted for 150 microseconds"));
   }
 }
@@ -1824,8 +1822,7 @@ void ppoll_h() {
   gpibBus.setControls(CIDS);
   delayMicroseconds(20);
   // Assert ATN and EOI
-  gpibBus.setControlVal(0b00000000, 0b10010000, 0);
-  //  setGpibState(0b10010000, 0b00000000, 0b10010000);
+  assertCtrl(ATN_BIT | EOI_BIT);
   delayMicroseconds(20);
   // Read data byte from GPIB bus without handshake
   sb = readGpibDbus();
@@ -2089,8 +2086,8 @@ void xdiag_h(char *params){
           break;
       case 1:
           // Set to required state
-          gpibBus.setControlVal(0xFF, 0xFF, 1);  // Set direction (all pins as outputs)
-          gpibBus.setControlVal(~byteval, 0xFF, 0);  // Set state (asserted=LOW so must invert value)
+	  outputCtrl(ALL_BITS);
+	  assertCtrl(ALL_BITS);
           // Reset after 10 seconds
           delay(10000);
           if (gpibBus.cfg.cmode==2) {

--- a/src/AR488/AR488_GPIBbus.cpp
+++ b/src/AR488/AR488_GPIBbus.cpp
@@ -313,14 +313,11 @@ bool GPIBbus::sendGET(uint8_t addr){
 
 /***** Send request to clear to all devices to local *****/
 void GPIBbus::sendAllClear(){
-  // Un-assert REN
-  setControlVal(0b00100000, 0b00100000, 0);
+  clearCtrl(REN_BIT);
   delay(40);
-  // Simultaneously assert ATN and REN
-  setControlVal(0b00000000, 0b10100000, 0);
+  assertCtrl(ATN_BIT | REN_BIT);
   delay(40);
-  // Unassert ATN
-  setControlVal(0b10000000, 0b10000000, 0);
+  clearCtrl(ATN_BIT);
 }
 
 
@@ -376,7 +373,7 @@ bool GPIBbus::sendMSA(uint8_t addr) {
     return ERR;
   }
   // Unassert ATN
-  setControlVal(0b10000000, 0b10000000, 0);
+  clearCtrl(ATN_BIT);
   return OK;
 }
 
@@ -907,12 +904,6 @@ void GPIBbus::setControls(uint8_t state) {
   // Save state
   cstate = state;
 
-}
-
-
-/***** Set GPI control state using numeric input (xdiag_h) *****/
-void GPIBbus::setControlVal(uint8_t value, uint8_t mask, uint8_t mode){
-  setGpibState(value, mask, mode);
 }
 
 

--- a/src/AR488/AR488_GPIBbus.cpp
+++ b/src/AR488/AR488_GPIBbus.cpp
@@ -129,7 +129,7 @@ bool GPIBbus::isAsserted(uint8_t gpibsig){
     // Clear mcpIntA flag
 //    clearMcpIntFlag();
     // Get inverse of pin status at interrupt (0 = true [asserted]; 1 = false [unasserted])
-    // Calling getMcpIntAPinState clears the interrupt 
+    // Calling getMcpIntAPinState clears the interrupt
 //    mcpPinAssertedReg = ~getMcpIntAPinState();
     mcpPinAssertedReg = ~getMcpIntAReg();
 //dataPort.print(F("mcpPinAssertedReg: "));
@@ -186,30 +186,30 @@ void GPIBbus::sendIFC(){
 
 /***** Send SDC GPIB command *****/
 bool GPIBbus::sendSDC(){
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
   DB_PRINT(F("sending SDC..."),"");
 #endif
   if (addressDevice(cfg.paddr, 0)) {
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
     DB_PRINT(F("failed to address the device."),"");
 #endif
     return ERR;
   }
   // Send SDC to currently addressed device
   if (sendCmd(GC_SDC)) {
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
      DB_PRINT(F("failed to send SDC to device"),"");
 #endif
      return ERR;
   }
   // Unlisten bus
   if (unAddressDevice()) {
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
     DB_PRINT(F("failed to unlisten the GPIB bus"),"");
 #endif
     return ERR;
   }
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
   DB_PRINT(F("done."),"");
 #endif
   return OK;
@@ -218,30 +218,30 @@ bool GPIBbus::sendSDC(){
 
 /***** Send LLO GPIB command *****/
 bool GPIBbus::sendLLO(){
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
   DB_PRINT(F("sending LLO..."),"");
 #endif
   if (addressDevice(cfg.paddr, 0)) {
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
     DB_PRINT(F("failed to address the device."),"");
 #endif
     return ERR;
   }
   // Send LLO to currently addressed device
   if (sendCmd(GC_LLO)) {
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
      DB_PRINT(F("failed to send LLO to device"),"");
 #endif
      return ERR;
   }
   // Unlisten bus
   if (unAddressDevice()) {
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
     DB_PRINT(F("failed to unlisten the GPIB bus"),"");
 #endif
     return ERR;
   }
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
   DB_PRINT(F("done."),"");
 #endif
   return OK;
@@ -250,30 +250,30 @@ bool GPIBbus::sendLLO(){
 
 /***** Send LOC GPIB command *****/
 bool GPIBbus::sendGTL(){
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
   DB_PRINT(F("sending LOC..."),"");
 #endif
   if (addressDevice(cfg.paddr, 0)) {
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
     DB_PRINT(F("failed to address the device."),"");
 #endif
     return ERR;
   }
   // Send GTL
   if (sendCmd(GC_GTL)) {
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
     DB_PRINT(F("failed to send LOC to device"),"");
 #endif
     return ERR;
   }
   // Unlisten bus
   if (unAddressDevice()) {
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
     DB_PRINT(F("failed to unlisten the GPIB bus"),"");
 #endif
-    return ERR;  
+    return ERR;
   }
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
   DB_PRINT(F("done."),"");
 #endif
   return OK;
@@ -282,30 +282,30 @@ bool GPIBbus::sendGTL(){
 
 /***** Send GET (trigger) command *****/
 bool GPIBbus::sendGET(uint8_t addr){
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
   DB_PRINT(F("sending GET..."),"");
 #endif
   if (addressDevice(addr, 0)) {
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
     DB_PRINT(F("failed to address the device."),"");
 #endif
     return ERR;
   }
   // Send GET
   if (sendCmd(GC_GET)) {
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
     DB_PRINT(F("failed to send LOC to device"),"");
 #endif
     return ERR;
   }
   // Unlisten bus
   if (unAddressDevice()) {
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
     DB_PRINT(F("failed to unlisten the GPIB bus"),"");
 #endif
-    return ERR;  
+    return ERR;
   }
-#ifdef DEBUG_GPIB_COMMANDS    
+#ifdef DEBUG_GPIB_COMMANDS
   DB_PRINT(F("done."),"");
 #endif
   return OK;
@@ -366,7 +366,7 @@ bool GPIBbus::sendMLA(){
   return OK;
 }
 
-    
+
 /***** Send secondary address command *****/
 bool GPIBbus::sendMSA(uint8_t addr) {
   // Send address
@@ -434,7 +434,7 @@ bool GPIBbus::sendCmd(uint8_t cmdByte){
     DB_PRINT(F("Failed to send command "), hexstr);
     DB_PRINT(F("  to device "), cfg.paddr);
   }
-#endif  
+#endif
   return stat ? ERR : OK;
 }
 
@@ -463,18 +463,18 @@ bool GPIBbus::receiveData(Stream& dataStream, bool detectEoi, bool detectEndByte
 
   // Set up for reading in Controller mode
   if (cfg.cmode == 2) {   // Controler mode
-    
+
     // Address device to talk
     if (addressDevice(cfg.paddr, 1)) {
 #ifdef DEBUG_GPIBbus_RECEIVE
       DB_PRINT(F("Failed to address device to talk: "), cfg.paddr);
 #endif
     }
-   
+
     // Wait for instrument ready
     // Set GPIB control lines to controller read mode
     setControls(CLAS);
-    
+
   // Set up for reading in Device mode
   } else {  // Device mode
     // Set GPIB controls to device read mode
@@ -482,7 +482,6 @@ bool GPIBbus::receiveData(Stream& dataStream, bool detectEoi, bool detectEndByte
     readWithEoi = true;  // In device mode we read with EOI by default
   }
 
-  
 #ifdef DEBUG_GPIBbus_RECEIVE
   DB_PRINT(F("Start listen ->"),"");
   DB_PRINT(F("Before loop flags:"),"");
@@ -614,7 +613,7 @@ void GPIBbus::sendData(char *data, uint8_t dsize) {
   } else {
     setControls(DTAS);
   }
-  
+
 #ifdef DEBUG_GPIBbus_SEND
   DB_PRINT(F("write data mode is set."),"");
   DB_PRINT(F("begin send loop->"),"");
@@ -630,7 +629,7 @@ void GPIBbus::sendData(char *data, uint8_t dsize) {
       // Otherwise ignore non-escaped CR, LF and ESC
       if ((data[i] != CR) && (data[i] != LF) && (data[i] != ESC)) err = writeByte(data[i], NO_EOI);
     }
-    
+
 #ifdef DEBUG_GPIBbus_SEND
     DB_RAW_PRINT(data[i]);
 #endif
@@ -674,7 +673,7 @@ void GPIBbus::sendData(char *data, uint8_t dsize) {
   }
 
   if (cfg.cmode == 2) {   // Controller mode
-/*    
+/*
     if (!err) {
       if (!addressingSuppressed) {
         // Untalk controller and unlisten bus
@@ -701,7 +700,6 @@ void GPIBbus::sendData(char *data, uint8_t dsize) {
 #ifdef DEBUG_GPIBbus_SEND
     DB_PRINT(F("done."),"");
 #endif
- 
 }
 
 
@@ -754,7 +752,7 @@ void GPIBbus::setControls(uint8_t state) {
   #ifdef SN7516X_SC
         digitalWrite(SN7516X_SC,HIGH);
   #endif
-#endif      
+#endif
 #ifdef DEBUG_GPIBbus_CONTROL
       DB_PRINT(F("Initialised GPIB control mode"),"");
 #endif
@@ -765,7 +763,7 @@ void GPIBbus::setControls(uint8_t state) {
       setGpibState(0b11011111, 0b10011110, 0);
 #ifdef SN7516X
       digitalWrite(SN7516X_TE,LOW);
-#endif      
+#endif
 #ifdef DEBUG_GPIBbus_CONTROL
       DB_PRINT(F("Set GPIB lines to idle state"),"");
 #endif
@@ -776,7 +774,7 @@ void GPIBbus::setControls(uint8_t state) {
       setGpibState(0b01011111, 0b10011111, 0);
 #ifdef SN7516X
       digitalWrite(SN7516X_TE,HIGH);
-#endif      
+#endif
 #ifdef DEBUG_GPIBbus_CONTROL
       DB_PRINT(F("Set GPIB lines for sending a command"),"");
 #endif
@@ -788,7 +786,7 @@ void GPIBbus::setControls(uint8_t state) {
       setGpibState(0b11011000, 0b10011110, 0);
 #ifdef SN7516X
       digitalWrite(SN7516X_TE,LOW);
-#endif      
+#endif
 #ifdef DEBUG_GPIBbus_CONTROL
       DB_PRINT(F("Set GPIB lines for reading data"),"");
 #endif
@@ -799,7 +797,7 @@ void GPIBbus::setControls(uint8_t state) {
       setGpibState(0b11011111, 0b10011110, 0);
 #ifdef SN7516X
       digitalWrite(SN7516X_TE,HIGH);
-#endif      
+#endif
 #ifdef DEBUG_GPIBbus_CONTROL
       DB_PRINT(F("Set GPIB lines for writing data"),"");
 #endif
@@ -812,10 +810,10 @@ void GPIBbus::setControls(uint8_t state) {
 #ifdef SN7516X
       digitalWrite(SN7516X_TE,HIGH);
   #ifdef SN7516X_DC
-        digitalWrite(SN7516X_DC,HIGH);
+      digitalWrite(SN7516X_DC,HIGH);
   #endif
   #ifdef SN7516X_SC
-        digitalWrite(SN7516X_SC,LOW);
+      digitalWrite(SN7516X_SC,LOW);
   #endif
 #endif      
       setGpibState(0b00000000, 0b11111111, 1);
@@ -887,7 +885,7 @@ void GPIBbus::setDataVal(uint8_t value){
 }
 
 
-/***** Flag more data to come - suppress addressing *****/ 
+/***** Flag more data to come - suppress addressing *****/
 /*
 void GPIBbus::setDataContinuity(bool flag){
   dataContinuity = flag;
@@ -1005,7 +1003,7 @@ uint8_t GPIBbus::readByte(uint8_t *db, bool readWithEoi, bool *eoi) {
         DB_PRINT(F("IFC detected]"),"");
 #endif
         stage = 1;
-        break;    
+        break;
       }
 
       // ATN unasserted during handshake - not ready yet so abort (and exit ATN loop)
@@ -1014,7 +1012,7 @@ uint8_t GPIBbus::readByte(uint8_t *db, bool readWithEoi, bool *eoi) {
         break;
       }
 
-    }  
+    }
 
     if (stage == 4) {
       // Unassert NRFD (we are ready for more data)
@@ -1049,7 +1047,7 @@ uint8_t GPIBbus::readByte(uint8_t *db, bool readWithEoi, bool *eoi) {
         // Re-assert NDAC - handshake complete, ready to accept data again
         setGpibState(0b00000000, 0b00000010, 0);
         stage = 9;
-        break;     
+        break;
       }
     }
 
@@ -1063,7 +1061,7 @@ uint8_t GPIBbus::readByte(uint8_t *db, bool readWithEoi, bool *eoi) {
 
 //  if (stage==1) return 4;
 //  if (stage==2) return 3;
-  
+
   // Otherwise return stage
 #ifdef DEBUG_GPIBbus_RECEIVE
   if ( (stage==4) || (stage==8) ) {
@@ -1090,17 +1088,17 @@ uint8_t GPIBbus::writeByte(uint8_t db, bool isLastByte) {
     if (cfg.cmode == 1) {
       // If IFC has been asserted then abort
       if (isAsserted(IFC)) {
-        setControls(DLAS);       
+        setControls(DLAS);
 #ifdef DEBUG_GPIBbus_SEND
         DB_PRINT(F("IFC detected!"),"");
 #endif
         stage = 1;
-        break;    
+        break;
       }
 
       // If ATN has been asserted we need to abort and listen
       if (isAsserted(ATN)) {
-        setControls(DLAS);       
+        setControls(DLAS);
 #ifdef DEBUG_GPIBbus_SEND
         DB_PRINT(F("ATN detected!"),"");
 #endif
@@ -1127,7 +1125,7 @@ uint8_t GPIBbus::writeByte(uint8_t db, bool isLastByte) {
       if (cfg.eoi && isLastByte) {
         // If EOI enabled and this is the last byte then assert DAV and EOI
 #ifdef DEBUG_GPIBbus_SEND
-        DB_PRINT(F("Asserting EOI..."),"");    
+        DB_PRINT(F("Asserting EOI..."),"");
 #endif
         setGpibState(0b00000000, 0b00011000, 0);
       }else{

--- a/src/AR488/AR488_GPIBbus.cpp
+++ b/src/AR488/AR488_GPIBbus.cpp
@@ -154,9 +154,10 @@ void GPIBbus::sendStatus() {
   writeByte(cfg.stat, NO_EOI);
   setControls(DIDS);
   // Clear the SRQ bit
-  cfg.stat = cfg.stat & ~0x40;
+  cfg.stat = cfg.stat & ~(SRQ_BIT);
   // De-assert the SRQ signal
-  clrSrqSig();
+  inputCtrl(SRQ_BIT);
+  clearCtrl(SRQ_BIT);
 }
 
 
@@ -165,10 +166,12 @@ void GPIBbus::setStatus(uint8_t statusByte){
   cfg.stat = statusByte;
   if (statusByte & 0x40) {
     // If SRQ bit is set then assert the SRQ signal
-    setSrqSig();
+    outputCtrl(SRQ_BIT);
+    assertCtrl(SRQ_BIT);
   } else {
     // If SRQ bit is NOT set then de-assert the SRQ signal
-    clrSrqSig();
+    inputCtrl(SRQ_BIT);
+    clearCtrl(SRQ_BIT);
   }
 }
 
@@ -1285,21 +1288,6 @@ bool GPIBbus::isTerminatorDetected(uint8_t bytes[3], uint8_t eorSequence){
   return false;
 }
 
-
-/***** Set the SRQ signal *****/
-void GPIBbus::setSrqSig() {
-  // Set SRQ line to OUTPUT HIGH (asserted)
-  setGpibState(0b01000000, 0b01000000, 1);
-  setGpibState(0b00000000, 0b01000000, 0);
-}
-
-
-/***** Clear the SRQ signal *****/
-void GPIBbus::clrSrqSig() {
-  // Set SRQ line to INPUT_PULLUP (un-asserted)
-  setGpibState(0b00000000, 0b01000000, 1);
-  setGpibState(0b01000000, 0b01000000, 0);
-}
 
 
 /***** ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ *****/

--- a/src/AR488/AR488_GPIBbus.h
+++ b/src/AR488/AR488_GPIBbus.h
@@ -186,8 +186,6 @@ class GPIBbus {
 //    bool writeByteHandshake(uint8_t db);
 //    boolean waitOnPinState(uint8_t state, uint8_t pin, int interval);
     bool isTerminatorDetected(uint8_t bytes[3], uint8_t eorSequence);
-    void setSrqSig();
-    void clrSrqSig();
 
     // Interrupt flag for MCP23S17
 #if defined(AR488_MCP23S17) || defined(AR488_MCP23017)

--- a/src/AR488/AR488_GPIBbus.h
+++ b/src/AR488/AR488_GPIBbus.h
@@ -165,7 +165,6 @@ class GPIBbus {
     bool receiveData(Stream& dataStream, bool detectEoi, bool detectEndByte, uint8_t endByte);
     void sendData(char *data, uint8_t dsize);
     void clearDataBus();
-    void setControlVal(uint8_t value, uint8_t mask, uint8_t mode);
     void setDataVal(uint8_t);
 
 //    void setDeviceAddressedState(uint8_t stat);

--- a/src/AR488/AR488_GPIBbus.h
+++ b/src/AR488/AR488_GPIBbus.h
@@ -80,6 +80,15 @@
 /***** GPIB COMMAND & STATUS DEFINITIONS *****/
 /*********************************************/
 
+#define IFC_BIT   (1 << 0)
+#define NDAC_BIT  (1 << 1)
+#define NRFD_BIT  (1 << 2)
+#define DAV_BIT   (1 << 3)
+#define EOI_BIT   (1 << 4)
+#define REN_BIT   (1 << 5)
+#define SRQ_BIT   (1 << 6)
+#define ATN_BIT   (1 << 7)
+#define ALL_BITS  (0xff)
 
 /****************************************/
 /***** GPIB CLASS OBJECT DEFINITION *****/

--- a/src/AR488/AR488_Layouts.cpp
+++ b/src/AR488/AR488_Layouts.cpp
@@ -1,6 +1,7 @@
 #include <Arduino.h>
 
 #include "AR488_Config.h"
+#include "AR488_GPIBbus.h"
 #include "AR488_Layouts.h"
 
 /***** AR488_Hardware.cpp, ver. 0.51.18, 26/02/2023 *****/
@@ -12,6 +13,23 @@
 volatile bool isATN = false;  // has ATN been asserted?
 volatile bool isSRQ = false;  // has SRQ been asserted?
 */
+
+void inputCtrl(uint8_t mask) {
+  setGpibState(0,mask,1);
+}
+
+void outputCtrl(uint8_t mask) {
+  setGpibState(ALL_BITS,mask,1);
+}
+
+void assertCtrl(uint8_t mask) {
+  setGpibState(0,mask,0);
+}
+
+void clearCtrl(uint8_t mask) {
+  setGpibState(ALL_BITS,mask,0);
+}
+
 
 /*********************************/
 /***** UNO/NANO BOARD LAYOUT *****/

--- a/src/AR488/AR488_Layouts.h
+++ b/src/AR488/AR488_Layouts.h
@@ -386,6 +386,10 @@ uint8_t readGpibDbus();
 void setGpibDbus(uint8_t db);
 void setGpibState(uint8_t bits, uint8_t mask, uint8_t mode);
 uint8_t getGpibPinState(uint8_t pin);
+void inputCtrl(uint8_t mask);
+void outputCtrl(uint8_t mask);
+void assertCtrl(uint8_t mask);
+void clearCtrl(uint8_t mask);
 
 /***** ^^^^^^^^^^^^^^^^^^^^^^^^^^ *****/
 /***** GLOBAL DEFINITIONS SECTION *****/


### PR DESCRIPTION
Request For Comment:

I was having trouble following the magic numbers in AR488_GPIBbus.cpp, so I rewrote the setGpibState() calls as simpler, easier to read inputCtrl(), outputCtrl(), assertCtrl() and clearCtrl() calls with defined foo_BIT values OR'd as indicated in the translated setGpibState() calls. I also noted where the values didn't make sense with a WHUT? comment. Setting a value for INPUTs might make sense to activate/disable pullups, but setting the pin as INPUT_PULLUP ought to do that already? More egregious and possibly indicating a logic error is where the bits to set were not including in the mask. Those cases should probably be looked at to confirm they are correct. For now, the new functions just call special cases of the setGpibState(), but could be re-implemented in a microcontroller/board specific way. E.g. the Teensy 3.1 I am working with has special registers available for setting/clearing bits for the various PORTs atomically.

I am interested in feedback on the approach, and any feedback on the apparent logic errors.