### PR TITLE
EESIZE was set too big for some processors

### DIFF
--- a/src/AR488/AR488_Eeprom.h
+++ b/src/AR488/AR488_Eeprom.h
@@ -13,12 +13,12 @@
  * ATmega644         2048   // MightyCore 644
  * ATmega328/32u4    1024   // Uno, Nano, Leonardo
  * ATmega168          512
- * ARmega4809         256   // Nano Every
+ * ATmega4809         256   // Nano Every
  * ESP8266/ESP32     none   // Emulated. 512kb assigned?
  */
 
 
-#define EESIZE 512
+#define EESIZE 256
 #define EESTART 2    // EEPROM start of data - min 4 for CRC32, min 2 for CRC16
 #define UPCASE true
 


### PR DESCRIPTION
The only use of the EEPROM is now `gpibBus.cfg.db` with size 83.

The EEPROM size is set to 512 in `AR488_Eeprom.h`, and `epErase()` uses that entire space.

But the ATmega4809 only has 256, so: potential problem.

Proposition to solve that discrepancy is in this PR. Simple.