### PR TITLE
Allow maxSize in receiveData()

### DIFF
--- a/src/AR488/AR488.ino
+++ b/src/AR488/AR488.ino
@@ -476,7 +476,7 @@ if (lnRdy>0){
       // Auto-read data from GPIB bus following any command
       if (gpibBus.cfg.amode == 1) {
         gpibBus.addressDevice(gpibBus.cfg.paddr, gpibBus.cfg.saddr, TOTALK);
-        errFlg = gpibBus.receiveData(dataPort, gpibBus.cfg.eoi, false, 0);
+        errFlg = gpibBus.receiveData(dataPort, gpibBus.cfg.eoi, false, 0, 0);
         if (gpibBus.cfg.hflags & 0x02) showFlag(F("Read^OK"));
         gpibBus.unAddressDevice();
       }
@@ -484,7 +484,7 @@ if (lnRdy>0){
       // Auto-receive data from GPIB bus following a query command
       if (gpibBus.cfg.amode == 2 && isQuery) {
         gpibBus.addressDevice(gpibBus.cfg.paddr, gpibBus.cfg.saddr, TOTALK);
-        errFlg = gpibBus.receiveData(dataPort, gpibBus.cfg.eoi, false, 0);
+        errFlg = gpibBus.receiveData(dataPort, gpibBus.cfg.eoi, false, 0, 0);
         if (gpibBus.cfg.hflags & 0x02) showFlag(F("Read^OK"));
         isQuery = false;
         gpibBus.unAddressDevice();
@@ -497,7 +497,7 @@ if (lnRdy>0){
       // Nothing is waiting on the serial input so read data from GPIB
       if (lnRdy==0) {
         if (gpibBus.haveAddressedDevice() == TONONE) gpibBus.addressDevice(gpibBus.cfg.paddr, gpibBus.cfg.saddr, TOTALK);
-        errFlg = gpibBus.receiveData(dataPort, readWithEoi, readWithEndByte, endByte);
+        errFlg = gpibBus.receiveData(dataPort, readWithEoi, readWithEndByte, endByte, 0);
         if (gpibBus.cfg.hflags & 0x02) showFlag(F("Read^OK"));
       }
     }
@@ -1413,7 +1413,7 @@ void read_h(char *params) {
     autoRead = true;
   } else {
     // If auto mode is disabled we do a single read
-    gpibBus.receiveData(dataPort, readWithEoi, readWithEndByte, endByte);
+    gpibBus.receiveData(dataPort, readWithEoi, readWithEndByte, endByte, 0);
     if (gpibBus.cfg.hflags & 0x02) showFlag(F("Read^OK"));
     gpibBus.unAddressDevice();
   }
@@ -2114,7 +2114,7 @@ void repeat_h(char *params) {
         // Send string to instrument
         gpibBus.sendData(param, strlen(param));
         delay(tmdly);
-        gpibBus.receiveData(dataPort, gpibBus.cfg.eoi, false, 0);
+        gpibBus.receiveData(dataPort, gpibBus.cfg.eoi, false, 0, 0);
       }
     } else {
       errorMsg(2);
@@ -2699,7 +2699,7 @@ Serial.println(param);
 
     if (gpibBus.cfg.amode == 1) {
       gpibBus.addressDevice(pri, sec, TOTALK);
-      gpibBus.receiveData(dataPort, gpibBus.cfg.eoi, false, 0);
+      gpibBus.receiveData(dataPort, gpibBus.cfg.eoi, false, 0, 0);
       if (gpibBus.cfg.hflags & 0x02) showFlag(F("Read^OK"));
       gpibBus.unAddressDevice();
     }
@@ -2761,7 +2761,7 @@ void secread_h(char *params) {
     gpibBus.setControls(CIDS);
     delay(50);
     gpibBus.addressDevice(pri, sec, TOTALK);
-    gpibBus.receiveData(dataPort, true, false, 0);
+    gpibBus.receiveData(dataPort, true, false, 0, 0);
     gpibBus.unAddressDevice();
 
   }else{
@@ -3068,8 +3068,8 @@ void execGpibCmd(uint8_t gpibcmd){
 
 /***** Device is addressed to listen - so listen *****/
 void device_listen_h(){
-  // Receivedata params: stream, detectEOI, detectEndByte, endByte
-  gpibBus.receiveData(dataPort, false, false, 0x0);
+  // Receivedata params: stream, detectEOI, detectEndByte, endByte, maxSize
+  gpibBus.receiveData(dataPort, false, false, 0x0, 0);
 }
 
 

--- a/src/AR488/AR488.ino
+++ b/src/AR488/AR488.ino
@@ -476,7 +476,7 @@ if (lnRdy>0){
       // Auto-read data from GPIB bus following any command
       if (gpibBus.cfg.amode == 1) {
         gpibBus.addressDevice(gpibBus.cfg.paddr, gpibBus.cfg.saddr, TOTALK);
-        errFlg = gpibBus.receiveData(dataPort, gpibBus.cfg.eoi, false, 0, 0);
+        errFlg = gpibBus.receiveData(dataPort, gpibBus.cfg.eoi, false, 0);
         if (gpibBus.cfg.hflags & 0x02) showFlag(F("Read^OK"));
         gpibBus.unAddressDevice();
       }
@@ -484,7 +484,7 @@ if (lnRdy>0){
       // Auto-receive data from GPIB bus following a query command
       if (gpibBus.cfg.amode == 2 && isQuery) {
         gpibBus.addressDevice(gpibBus.cfg.paddr, gpibBus.cfg.saddr, TOTALK);
-        errFlg = gpibBus.receiveData(dataPort, gpibBus.cfg.eoi, false, 0, 0);
+        errFlg = gpibBus.receiveData(dataPort, gpibBus.cfg.eoi, false, 0);
         if (gpibBus.cfg.hflags & 0x02) showFlag(F("Read^OK"));
         isQuery = false;
         gpibBus.unAddressDevice();
@@ -497,7 +497,7 @@ if (lnRdy>0){
       // Nothing is waiting on the serial input so read data from GPIB
       if (lnRdy==0) {
         if (gpibBus.haveAddressedDevice() == TONONE) gpibBus.addressDevice(gpibBus.cfg.paddr, gpibBus.cfg.saddr, TOTALK);
-        errFlg = gpibBus.receiveData(dataPort, readWithEoi, readWithEndByte, endByte, 0);
+        errFlg = gpibBus.receiveData(dataPort, readWithEoi, readWithEndByte, endByte);
         if (gpibBus.cfg.hflags & 0x02) showFlag(F("Read^OK"));
       }
     }
@@ -1413,7 +1413,7 @@ void read_h(char *params) {
     autoRead = true;
   } else {
     // If auto mode is disabled we do a single read
-    gpibBus.receiveData(dataPort, readWithEoi, readWithEndByte, endByte, 0);
+    gpibBus.receiveData(dataPort, readWithEoi, readWithEndByte, endByte);
     if (gpibBus.cfg.hflags & 0x02) showFlag(F("Read^OK"));
     gpibBus.unAddressDevice();
   }
@@ -2114,7 +2114,7 @@ void repeat_h(char *params) {
         // Send string to instrument
         gpibBus.sendData(param, strlen(param));
         delay(tmdly);
-        gpibBus.receiveData(dataPort, gpibBus.cfg.eoi, false, 0, 0);
+        gpibBus.receiveData(dataPort, gpibBus.cfg.eoi, false, 0);
       }
     } else {
       errorMsg(2);
@@ -2699,7 +2699,7 @@ Serial.println(param);
 
     if (gpibBus.cfg.amode == 1) {
       gpibBus.addressDevice(pri, sec, TOTALK);
-      gpibBus.receiveData(dataPort, gpibBus.cfg.eoi, false, 0, 0);
+      gpibBus.receiveData(dataPort, gpibBus.cfg.eoi, false, 0);
       if (gpibBus.cfg.hflags & 0x02) showFlag(F("Read^OK"));
       gpibBus.unAddressDevice();
     }
@@ -2761,7 +2761,7 @@ void secread_h(char *params) {
     gpibBus.setControls(CIDS);
     delay(50);
     gpibBus.addressDevice(pri, sec, TOTALK);
-    gpibBus.receiveData(dataPort, true, false, 0, 0);
+    gpibBus.receiveData(dataPort, true, false, 0);
     gpibBus.unAddressDevice();
 
   }else{
@@ -3068,8 +3068,8 @@ void execGpibCmd(uint8_t gpibcmd){
 
 /***** Device is addressed to listen - so listen *****/
 void device_listen_h(){
-  // Receivedata params: stream, detectEOI, detectEndByte, endByte, maxSize
-  gpibBus.receiveData(dataPort, false, false, 0x0, 0);
+  // Receivedata params: stream, detectEOI, detectEndByte, endByte
+  gpibBus.receiveData(dataPort, false, false, 0x0);
 }
 
 

--- a/src/AR488/AR488_GPIBbus.h
+++ b/src/AR488/AR488_GPIBbus.h
@@ -217,8 +217,8 @@ public:
   bool sendSecondaryCmd(uint8_t paddr, uint8_t saddr, char * data, uint8_t dsize);
   enum gpibHandshakeState readByte(uint8_t *db, bool readWithEoi, bool *eoi);
   enum gpibHandshakeState writeByte(uint8_t db, bool isLastByte);
-  enum receiveState receiveData(Stream &dataStream, bool detectEoi, bool detectEndByte, uint8_t endByte);
-  void sendData(char *data, uint8_t dsize);
+  enum receiveState receiveData(Stream &dataStream, bool detectEoi, bool detectEndByte, uint8_t endByte, int maxSize);
+  void sendData(const char *data, uint8_t dsize);
   void clearDataBus();
   void setControlVal(uint8_t value);
   void setDataVal(uint8_t value);

--- a/src/AR488/AR488_GPIBbus.h
+++ b/src/AR488/AR488_GPIBbus.h
@@ -218,7 +218,7 @@ public:
   enum gpibHandshakeState readByte(uint8_t *db, bool readWithEoi, bool *eoi);
   enum gpibHandshakeState writeByte(uint8_t db, bool isLastByte);
   enum receiveState receiveData(Stream &dataStream, bool detectEoi, bool detectEndByte, uint8_t endByte, int maxSize = 0);
-  void sendData(const char *data, uint8_t dsize);
+  void sendData(const char *data, uint8_t dsize, bool isLastPacket = true);
   void clearDataBus();
   void setControlVal(uint8_t value);
   void setDataVal(uint8_t value);

--- a/src/AR488/AR488_GPIBbus.h
+++ b/src/AR488/AR488_GPIBbus.h
@@ -217,7 +217,7 @@ public:
   bool sendSecondaryCmd(uint8_t paddr, uint8_t saddr, char * data, uint8_t dsize);
   enum gpibHandshakeState readByte(uint8_t *db, bool readWithEoi, bool *eoi);
   enum gpibHandshakeState writeByte(uint8_t db, bool isLastByte);
-  enum receiveState receiveData(Stream &dataStream, bool detectEoi, bool detectEndByte, uint8_t endByte, int maxSize);
+  enum receiveState receiveData(Stream &dataStream, bool detectEoi, bool detectEndByte, uint8_t endByte, int maxSize = 0);
   void sendData(const char *data, uint8_t dsize);
   void clearDataBus();
   void setControlVal(uint8_t value);


### PR DESCRIPTION
As mentioned in #59, here is a PR for the `maxSize` parameter. 

1) added `maxSize` to `ReceiveData()`, allowing stop reading when more than maxSize bytes were read.
It will also not set the bus to idle in that case. Default value: 0, meaning: no check of length.
EDIT: ~I opted for not using the construction `maxSize = 0` in the function definition, as the arduino compiler prints warning messages about that. The downside is that I had to adapt `AR488.ino`.~

2) Added a `bool isLastPacket` flag to `sendData()`. If the data sent is not the last data, the bus is not set to idle after the send. Default value: true, meaning: always consider this the last packet.

3) Added another small change: added the 'const' to `sendData(const char *data, ....)`, as the content of `data` is not modified in that function, and it helps me out in my code. That change has no impact on your code. 