### PR TITLE
correct EEPROM read/write for ESP32

### DIFF
--- a/src/AR488/AR488_Eeprom.cpp
+++ b/src/AR488/AR488_Eeprom.cpp
@@ -2,7 +2,7 @@
 #include <EEPROM.h>
 #include "AR488_Eeprom.h"
 
-/***** AR488_Eeprom.cpp, ver. 0.01.03, 28/04/2025 *****/
+/***** AR488_Eeprom.cpp, ver. 0.01.04, 26/06/2025 *****/
 /*
  * EEPROM functions implementation
  */
@@ -173,12 +173,13 @@ void epErase() {
  */
 void epWriteData(uint8_t cfgdata[], uint16_t cfgsize) {
   uint16_t crc;
-  uint16_t addr = EESTART;
+  int i;
   
   // Load EEPROM data from Flash
   EEPROM.begin(EESIZE);
   // Write data
-  EEPROM.put(addr,cfgdata);
+   for (i=0; i<cfgsize; i++)
+    EEPROM.write(i+EESTART, cfgdata[i]);
   // Write CRC
   crc = getCRC16(cfgdata, cfgsize);
   EEPROM.put(0, crc);
@@ -197,14 +198,15 @@ void epWriteData(uint8_t cfgdata[], uint16_t cfgsize) {
 bool epReadData(uint8_t cfgdata[], uint16_t cfgsize) {
   uint16_t crc1;
   uint16_t crc2;
-  uint16_t addr = EESTART;
+  int i;
 
   // Load EEPROM data from Flash
   EEPROM.begin(EESIZE);
   // Read CRC
   EEPROM.get(0,crc1);
   // Read data
-  EEPROM.get(addr, cfgdata);
+  for (i=0; i<cfgsize; i++)
+    cfgdata[i]=EEPROM.read(i+EESTART);
   EEPROM.end();
   // Get CRC of config
   crc2 = getCRC16(cfgdata, cfgsize);

--- a/src/AR488/AR488_Eeprom.h
+++ b/src/AR488/AR488_Eeprom.h
@@ -2,14 +2,22 @@
 #define AR488_EEPROM_H
 
 #include "AR488_Config.h"
-//#include <EEPROM.h>
+#include <EEPROM.h>
 
-/***** AR488_Eeprom.h, ver. 0.01.03, 28/04/2025 *****/
+
+/***** AR488_Eeprom.h, ver. 0.01.04, 26/06/2025 *****/
+
+#if defined(ESP8266) || defined(ESP32)
+#ifndef E2END
+#define E2END     //this is used as a flag for existing/nonexisting EEPROM
+#endif
+#endif
+
 
 /*
  * EEPROM SIZES:
- * 
- * ATmega2560/1284   4096   // Mega 2560, MightyCore 1284 
+ *
+ * ATmega2560/1284   4096   // Mega 2560, MightyCore 1284
  * ATmega644         2048   // MightyCore 644
  * ATmega328/32u4    1024   // Uno, Nano, Leonardo
  * ATmega168          512


### PR DESCRIPTION
the EEPROM read/write functions for ESP32 are using put/get from the eeprom library, that finds out the buffersize with "sizeof". But the variable that is passed is only a pointer to the buffer with the config-data - and so not the buffer is saved/restored  but the pointer. 
Hence ++savecfg is not working with ESP32
This is corrected.